### PR TITLE
change event name: rc3@hackeriet -> oslohack:22

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,33 +1,33 @@
 <!doctype html>
 <html>
     <head>
-        <title>rC3@hackeriet</title>
+        <title>oslohack:22</title>
         <link crossorigin="anonymous" media="all" rel="stylesheet" href="styles.css" />
         <link crossorigin="anonymous" media="all" rel="stylesheet" href="construction.css" />
     </head>
     <body>
         <div class="content">
-        <h1>rC3 @ hackeriet 2022</h1>
-            <h2 style="text-align: center;">A hacker conference in Oslo</h2>
-            <h2 style="text-align: center;">28-30 dec</h2>
-        <center>
-            <div class="construction"></div>
-        </center>
-
-        <h1>Coming soon!</h1>
+            <h1>oslohack:22</h1>
+            <h2 style="text-align: center;">A community conference at Hackeriet in Oslo</h2>
+            <h2 style="text-align: center;">28-30 dec 2022</h2>
+            <center>
+                <div class="construction"></div>
+            </center>
+            <h1>Coming soon!</h1>
             <h2 style="text-align: center;">
-                We're dusting off the <a href="2021.html">old plans from 2021</a>, and trying again!
+                We're dusting off the <a href="2021.html">old plans from 2021</a>,
+                and trying again!
             </h2>
-
         </div>
         <div class="cyber-wrap">
             <div class="cyber"></div>
         </div>
-
-                <div class="content">
-        </center>
-         <p><small>rC3@hackeriet is a community organized non-profit event &middot; CYBER sticker is CC-BY-NC fnordeingang e.V. &middot; Scrolling banner borrowed from <a href="https://cyber.equipment">cyber.equipment</a></small></p>
+        <div class="content">
+            <p><small>
+                OsloHack is a community organized non-profit event &middot;
+                CYBER sticker is CC-BY-NC fnordeingang e.V. &middot;
+                Scrolling banner borrowed from <a href="https://cyber.equipment">cyber.equipment</a>
+            </small></p>
         </div>
-
     </body>
 </html>


### PR DESCRIPTION
We've had a quick vote at hackeriet on changing the name of the event from RC3@hackeriet as it might collide with CCC etc:

- oslohack (5 votes)
- rc3 (1 vote)
- ELFcon (1 votes)
- hackeriet22 (0 votes)

Further discussions happened, and this PR changes the name (and port) of the event to `oslohack:22` or `oslohack.no:22`

(Domain is being registered)
